### PR TITLE
feat(recursive): full recursive support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,9 @@
       "type": "node",
       "request": "launch",
       "args": [
-        "${relativeFile}"
+        "${relativeFile}",
+        "-sstaging",
+        "-fexample/env.yml"
       ],
       "runtimeArgs": [
         "--nolazy",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ default_env: &default_env
   OPTIONAL_VARIABLE:  ## Optional variable syntax.  Undefined variables will otherwise cause failures
     value: ${env:SOME_POSSIBLY_UNDEFINED_VARIABLE}
     optional: true
+  ADVANCED_VALUE:  test-${env:SOME_ENV_VARIABLE}
 
 development:
   <<: *default_env
@@ -48,6 +49,16 @@ Then, run `yarn dotenvi -s <stage>` to generate a `.env` file for the stage desi
 
 Note that stages are not required in your yaml file - you can also define it without stages, in which case you should not specify a stage with the `-s` option when you run `dotenvi`.
 
+
+## Recursion
+
+Dotenvi now supports recursion.  You can specify an expression that returns another expression.  For example, if the following environment variables are defined:
+
+* `RECURSIVE_OUTER`: `${env:RECURSIVE_MIDDLE}-test`
+* `RECURSIVE_MIDDLE`: `foo${env:RECURSIVE_INNER}bar${env:RECURSIVE_INNER}`
+* `RECURSIVE_INNER`: `test`
+
+If you evaluate `${env:RECURSIVE_OUTER}`, it will return `footestbartest-test`.
 
 ## Configuration
 
@@ -85,4 +96,3 @@ The reference syntax used in `env.yml` is inspired by [serverless](https://githu
 
 1. Allow for `dotenvi` to replace `dotenv`, if desired, by skipping the `.env`-generation step.
 2. Support for references embedded within a configuration value (e.g., `foo-${env:BAR}` --> `foo-bar` if BAR=bar)
-3. Support recursive reference calls (e.g., `${env:${env:FOO}}`)

--- a/README.md
+++ b/README.md
@@ -95,4 +95,3 @@ The reference syntax used in `env.yml` is inspired by [serverless](https://githu
 ## Possible Future Work
 
 1. Allow for `dotenvi` to replace `dotenv`, if desired, by skipping the `.env`-generation step.
-2. Support for references embedded within a configuration value (e.g., `foo-${env:BAR}` --> `foo-bar` if BAR=bar)

--- a/example/env.yml
+++ b/example/env.yml
@@ -10,6 +10,7 @@ default_env: &default_env
   INTEGER_VALUE: 3000
   BOOLEAN_TRUE_VALUE: true
   BOOLEAN_FALSE_VALUE: false
+  VALUE_WITH_SURROUNDING_STRINGS: test-${IA_ENV}-test
 
 sandbox:
   <<: *default_env

--- a/src/rewriter.test.js
+++ b/src/rewriter.test.js
@@ -33,4 +33,30 @@ describe('Rewriter', () => {
     });
   });
 
+  it('Rewrites variables with surrounding strings', () => {
+    process.env['TEST'] = 'hello';
+    const document = {
+      'test': {
+        'value': 'test-${env:TEST}-test'
+      }
+    };
+
+    const rewriter = new Rewriter({ resolvers: resolvers });
+    return rewriter.rewrite(document).then((output) => {
+      expect(output['test']).toBe('test-hello-test');
+    });
+  });
+
+  it("Doesn't rewrite when surrounding expression returns undefined", () => {
+    const document = {
+      'test': {
+        'value': 'test-${env:UNDEFINED_ENV_VARIABLE}-test'
+      }
+    };
+
+    const rewriter = new Rewriter({ resolvers: resolvers });
+    return rewriter.rewrite(document).then((output) => {
+      expect(output['test']).toBe(undefined);
+    });
+  })
 });

--- a/src/rewriter.test.js
+++ b/src/rewriter.test.js
@@ -47,16 +47,35 @@ describe('Rewriter', () => {
     });
   });
 
-  it("Doesn't rewrite when inner expression returns undefined", () => {
+  it('Handles recursive rewrites', () => {
+    process.env['RECURSIVE_OUTER'] = '${env:RECURSIVE_INNER}';
+    process.env['RECURSIVE_INNER'] = 'test';
     const document = {
       'test': {
-        'value': 'test-${env:UNDEFINED_ENV_VARIABLE}-test'
+        'value': '${env:RECURSIVE_OUTER}'
       }
     };
 
     const rewriter = new Rewriter({ resolvers: resolvers });
     return rewriter.rewrite(document).then((output) => {
-      expect(output['test']).toBe(undefined);
+      expect(output['test']).toBe('test');
+    });
+  });
+
+
+  it('Handles complex recursive rewrites', () => {
+    process.env['RECURSIVE_OUTER2'] = '${env:RECURSIVE_MIDDLE2}-test';
+    process.env['RECURSIVE_MIDDLE2'] = 'foo${env:RECURSIVE_INNER2}bar${env:RECURSIVE_INNER2}'
+    process.env['RECURSIVE_INNER2'] = 'test';
+    const document = {
+      'test': {
+        'value': '${env:RECURSIVE_OUTER2}'
+      }
+    };
+
+    const rewriter = new Rewriter({ resolvers: resolvers });
+    return rewriter.rewrite(document).then((output) => {
+      expect(output['test']).toBe('footestbartest-test');
     });
   })
 });

--- a/src/rewriter.test.js
+++ b/src/rewriter.test.js
@@ -47,7 +47,7 @@ describe('Rewriter', () => {
     });
   });
 
-  it("Doesn't rewrite when surrounding expression returns undefined", () => {
+  it("Doesn't rewrite when inner expression returns undefined", () => {
     const document = {
       'test': {
         'value': 'test-${env:UNDEFINED_ENV_VARIABLE}-test'

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -15,18 +15,34 @@ export class Rewriter {
 
   private async rewriteValue(value: Primitive): Promise<Primitive> {
     if (typeof value === 'string') {
-      const regex = new RegExp('([^$]*)\\${([a-z]+):(.*)}(.*)');
-      const matchResults = value.match(regex);
-      const resolverName = matchResults && matchResults[2];
-      const innerValue = matchResults ? matchResults[3] : value;
-      const resolver = this.getResolver(resolverName);
-      if (!resolver) {
-        throw new Error(`Could not locate resolver for value ${value}`);
-      }
-      let result = await resolver(innerValue, this.config);
-      // If there are surrounding strings, only rewrite if result is non-null
-      if (result && matchResults) {
-        result = matchResults[1] + result + matchResults[4]
+      let result = '';
+      let capture = '';
+
+      for (let i = 0; i < value.length; ++i) {
+        const c = value.charAt(i);
+        if (c === '$') {
+          capture += c;
+        } else if (c == '}') {
+          capture += c;
+          const regex = new RegExp('\\${([a-z]+):(.*)}');
+          const matchResults = capture.match(regex);
+          const resolverName = matchResults && matchResults[1];
+          const resolver = this.getResolver(resolverName);
+          if (!resolver) {
+            throw new Error(`Could not locate resolver for value ${value}`);
+          }
+          const innerValue = matchResults ? matchResults[2] : value;
+          let innerResult = await resolver(innerValue, this.config);
+          if (!innerResult) {
+            throw new Error(`Resolver ${resolverName} didn't return any value`);
+          }
+          result += await this.rewriteValue(innerResult);
+          capture = '';
+        } else if (capture) {
+          capture += c;
+        } else {
+          result += c;
+        }
       }
       return result;
     } else {


### PR DESCRIPTION
Dotenvi now supports recursion.  You can specify an expression that returns another expression.  For example, if the following environment variables are defined:

* `RECURSIVE_OUTER`: `${env:RECURSIVE_MIDDLE}-test`
* `RECURSIVE_MIDDLE`: `foo${env:RECURSIVE_INNER}bar${env:RECURSIVE_INNER}`
* `RECURSIVE_INNER`: `test`

If you evaluate `${env:RECURSIVE_OUTER}`, it will return `footestbartest-test`.