### PR TITLE
feat(resolver): add support for alphanumeric (+ underscore) resolver names

### DIFF
--- a/src/rewriter.test.js
+++ b/src/rewriter.test.js
@@ -115,4 +115,19 @@ describe('Rewriter', () => {
       }
     });
   });
+
+  it('Handles full alphanumeric resolver', () => {
+    const document = {
+      test: {
+        value: '${1custom_Uppercaser:lowercase}'
+      }
+    };
+
+    const customUppercaser = async value => value.toUpperCase();
+
+    const rewriter = new Rewriter({ resolvers: { ...resolvers, '1custom_Uppercaser': customUppercaser } });
+    return rewriter.rewrite(document).then(output => {
+      expect(output['test']).toBe('LOWERCASE');
+    });
+  });
 });

--- a/src/rewriter.ts
+++ b/src/rewriter.ts
@@ -25,7 +25,7 @@ export class Rewriter {
           capture += c;
         } else if (c == '}') {
           capture += c;
-          const regex = new RegExp('\\${([a-z]+):(.*)}');
+          const regex = new RegExp('\\${([\\w]+):(.*)}');
           const matchResults = capture.match(regex);
           if (matchResults) {
             const resolverName = matchResults[1];


### PR DESCRIPTION
Modify matcher to look at `\w` instead of `a-z` for resolver names.

Added test for functionality.

Addresses #60 