### PR TITLE
 fix(credstash): replace nodecredstash with aws-credstash

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "@types/js-yaml": "^3.11.1",
     "@types/node": "^9.6.4",
     "argparse": "^1.0.10",
-    "aws-sdk": "^2.224.1",
+    "aws-credstash": "^3.0.0",
+    "aws-sdk": "^2.567.0",
     "bluebird": "^3.5.1",
-    "js-yaml": "^3.11.0",
-    "nodecredstash": "^2.0.2"
+    "js-yaml": "^3.11.0"
   },
   "devDependencies": {
     "jest": "^22.4.3",

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,7 +1,7 @@
 import * as AWS from 'aws-sdk';
 import { DescribeStacksOutput } from 'aws-sdk/clients/cloudformation';
 
-const Credstash = require('nodecredstash');
+const Credstash = require('aws-credstash');
 
 import { promisify } from 'bluebird';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,7 +342,7 @@ acorn@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-aes-js@^3.1.0:
+aes-js@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
   integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
@@ -632,12 +632,20 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.171.0, aws-sdk@^2.224.1:
-  version "2.648.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.648.0.tgz#6cbea887b98c3ee8316870e9eead659194e35094"
-  integrity sha512-b+PdZmCFvZBisqXEH68jO4xB30LrDHQMWrEX6MJoZaOlxPJfpOqRFUH3zsiAXF5Q2jTdjYLtS5bs3vcIwRzi3Q==
+aws-credstash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aws-credstash/-/aws-credstash-3.0.0.tgz#377de983c149a8a5471e1ff23c4550d35514b726"
+  integrity sha512-SBrCROAOBKQvxD2i/hh7WefhKscgW8W7jLXTYC9s0q1S2cX/1ugxYnlkZkBrXltIPRPBrAd6pcKjHsrPo5gV7Q==
   dependencies:
-    buffer "4.9.1"
+    aes-js "^3.1.2"
+    debug "^4.1.1"
+
+aws-sdk@^2.567.0:
+  version "2.780.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.780.0.tgz#ac88e5222cb4a09385791fbb5a58114ad5abc9c1"
+  integrity sha512-pz/3dJdrkqgJn2YPwu6/VaGBSvYm33wjb6Ic7zSuFPOduqo42Se70BQASNmUg1E8EBqSwsrYEW04f5XGOJ0mMA==
+  dependencies:
+    buffer "4.9.2"
     events "1.1.1"
     ieee754 "1.1.13"
     jmespath "0.15.0"
@@ -1417,10 +1425,10 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer@4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -2168,6 +2176,13 @@ debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -5420,7 +5435,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -5577,15 +5592,6 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-nodecredstash@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/nodecredstash/-/nodecredstash-2.0.2.tgz#2a36ae12534c4e975aafde1deafdd85773eb5dcb"
-  integrity sha512-gIQeGTdo8LwuK6dIUREQwUd2bPRcr575UgXIBE4vmN4UajRUXJvU18OQsCy5fQAahMzfJ4sbUyDYXcSdgrzgoA==
-  dependencies:
-    aes-js "^3.1.0"
-    aws-sdk "^2.171.0"
-    debug "^3.1.0"
 
 noop-logger@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
`nodecredstash` depends on `aws-sdk@^2.171.0`; this elderly version of
the AWS SDK lacks support for various contemporary features.  the author
doesn't want to convert that dependency to a peerDependency in order to
facilitate parent modules enforcing a newer version (see
DavidTanner/nodecredstash#13); as a result, someone else forked
`nodecredstash` into `aws-credstash`, which is API-compatible but moves
`aws-sdk` to a peerDependency.

`aws-credstash` seems to be more actively maintained than
`nodecredstash`; this change swaps in `aws-credstash` and also enforces
a dependency on a more recent `aws-sdk` (my particular need for that
minimum version is AWS SSO credential parsing support, i would be
open to enforcing a more recent minimum version).

the test suite passes after this change, i'm about to do some additional
testing to see if i can find anything else that breaks.