### PR TITLE
Add simple map to cache DescribeStacks calls and avoid calling multip…

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -33,7 +33,7 @@ class CloudFormationMock {
   describeStacks({ StackName }) {
     this.timesCalled += 1;
     if (StackName == 'throwError') {
-      throw 'CloudFormation Error';
+      throw new Error('CloudFormation Error');
     } else if (StackName == 'notFound') {
       this.stacks = {
         Stacks: []

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -3,6 +3,9 @@ const MOCK_SECRET_MANAGER_SECRET_STORE = {
   jsonString: JSON.stringify({ foo: 'bar', nested: { foo: 'bar' } })
 };
 
+// Mock the AWS config object
+const config = { region: 'us-east-1' };
+
 class SecretsManagerMock {
   constructor() {
     this.secret = {};
@@ -21,6 +24,57 @@ class SecretsManagerMock {
   }
 }
 
+class CloudFormationMock {
+  constructor() {
+    this.stacks = {};
+    this.timesCalled = 0;
+  }
+
+  describeStacks({ StackName }) {
+    this.timesCalled += 1;
+    if (StackName == 'throwError') {
+      throw 'CloudFormation Error';
+    } else if (StackName == 'notFound') {
+      this.stacks = {
+        Stacks: []
+      };
+    } else if (StackName == 'outputMissing') {
+      this.stacks = {
+        Stacks: [
+          {
+            Outputs: [
+              {
+                OutputKey: 'notFoo',
+                OutputValue: 'bar'
+              }
+            ]
+          }
+        ]
+      };
+    } else {
+      this.stacks = {
+        Stacks: [
+          {
+            Outputs: [
+              {
+                OutputKey: 'foo',
+                OutputValue: 'bar'
+              }
+            ]
+          }
+        ]
+      };
+    }
+    return this;
+  }
+
+  promise() {
+    return Promise.resolve(this.stacks);
+  }
+}
+
 module.exports = {
-  SecretsManager: SecretsManagerMock
+  SecretsManager: SecretsManagerMock,
+  CloudFormation: CloudFormationMock,
+  config
 };

--- a/src/resolvers.test.js
+++ b/src/resolvers.test.js
@@ -1,6 +1,9 @@
-const { resolvers } = require('./resolvers');
+const { resolvers, cft } = require('./resolvers');
 
 const asmSecretManagerResolver = resolvers.asm;
+const cftResolver = resolvers.cft;
+
+const AWS = require('aws-sdk');
 
 describe('ASM Resolver', () => {
   it('returns json secret value', () => {
@@ -35,6 +38,41 @@ describe('ASM Resolver', () => {
 
   it('returns undefined if json key string invalid', () => {
     return asmSecretManagerResolver('invalidJsonString.invalid').then(output => {
+      expect(output).toBe(undefined);
+    });
+  });
+});
+
+describe('Cloudformation Output Resolver', () => {
+  it('returns cft output value', () => {
+    return cftResolver('testStack.foo').then(output => {
+      expect(output).toBe('bar');
+    });
+  });
+
+  it('calls to Cloudformation are cached', async () => {
+    const startTimesCalled = cft.timesCalled;
+    await cftResolver('newStack.foo');
+    await cftResolver('newStack.bar');
+    expect(cft.timesCalled - startTimesCalled).toBe(1);
+    await cftResolver('differentStack.foo');
+    expect(cft.timesCalled - startTimesCalled).toBe(2);
+  });
+
+  it('returns undefined when error is thrown', () => {
+    return cftResolver('throwError.foo').then(output => {
+      expect(output).toBe(undefined);
+    });
+  });
+
+  it('returns undefined when stack is not found', () => {
+    return cftResolver('notFound.foo').then(output => {
+      expect(output).toBe(undefined);
+    });
+  });
+
+  it('returns undefined when output is not found', () => {
+    return cftResolver('outputMissing.foo').then(output => {
       expect(output).toBe(undefined);
     });
   });


### PR DESCRIPTION
…le times

I've tested and verified against CloudTrail calls to see that only one call per-stack is called, even if multiple outputs are requested.

Sample:
```
outputX: ${cft:Stack1.outputX}
outputY: ${cft:Stack1.outputY}
outputFoo: ${cft:Stack2.outputFoo}
```

Before - This makes three `describeStacks` calls, getting (likely) identical data each time for the two `Stack1` calls.
After - This makes two `describeStacks` cals, caching the result of the `Stack1` lookup.